### PR TITLE
Rename /tip command to /zap

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -83,7 +83,7 @@ async function handleError(error:Error, ctx:Context){
         message = "You're trying to send 0 satoshi? That doesn't make any sense!"
     }
     if(error instanceof CommandSyntaxError){
-        message = "Oops, something went wrong! Please use the correct syntax: /tip <username> <amount>. For example: /tip @username 10"
+        message = "Oops, something went wrong! Please use the correct syntax: /zap <username> <amount>. For example: /zap @username 10"
     }
     if(error instanceof ReceiverNotConnectedError){
         message = `Sorry, but receiver hasn't connected to this bot. They can't receive your tip!`;

--- a/src/handlers/commandHandlers.ts
+++ b/src/handlers/commandHandlers.ts
@@ -20,8 +20,8 @@ export async function handleHelp(ctx: CommandContext<MyContext>) {
     await ctx.reply("Hey! I'm your go-to bot for fast bitcoin transactions in Telegram chats.\n\n" +
         "Commands:\n\n" +
         "• Hook up your NWC wallet: /connection\n" +
-        "• Throw a tip to a user: /tip <username> <amount>\n" +
-        "• Tip by replying to a message: /tip <amount>\n" +
+        "• Throw a tip to a user: /zap <username> <amount>\n" +
+        "• Tip by replying to a message: /zap <amount>\n" +
         "• For more info about Nostr wallet connect use /nwc \n\n " +
         "Wanna keep me running? Feel free to send tips for bot maintenance (servers, databases, and all that jazz).");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ bot.use(createConversation(connection));
 bot.command('start', handleStart);
 bot.command('help', handleHelp);
 bot.command('connection', handleConnection);
-bot.command('tip', handleTip);
+bot.command('zap', handleTip);
 bot.command('balance', handleBalance);
 bot.command('nwc', handleNwcInfo);
 


### PR DESCRIPTION
Update the user-facing command from /tip to /zap while keeping internal function names unchanged (handleTip, tipAmount, etc.) since the project is still conceptually about tipping.

Let me know if you prefer to rename the functions to 'zap'. I decided to leave the internal wording to tip, because this is just resolving a conflict when 2 bots are around and the bot still has **Tip** in the name: Thunder**Tip**.